### PR TITLE
fix: 修复基座应用main-vue2的别名设置

### DIFF
--- a/examples/main-vue2/vue.config.js
+++ b/examples/main-vue2/vue.config.js
@@ -21,6 +21,6 @@ module.exports = {
   },
   chainWebpack: config => {
     config.resolve.alias
-      .set("@micro-zoe/micro-app", path.join(__dirname, '../../lib/index.esm.js'))
+    .set("@micro-zoe/micro-app", '@micro-zoe/micro-app/lib/index.esm.js')
   },
 }


### PR DESCRIPTION
examples/main-vue2中安装依赖启动后报错找不到依赖包，修改配置文件中的别名设置后成功启动