### PR TITLE
fix: formatURL方法兼容更多场景

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -63,13 +63,13 @@ export function formatURL (url: string | null): string {
   if (typeof url !== 'string' || !url) return ''
 
   try {
-    const { origin, pathname } = new URL(addProtocol(url))
-    // If it ends with .html, don’t need to add /
-    if (/\.html$/.test(pathname)) {
-      return `${origin}${pathname}`
+    const { origin, pathname, search } = new URL(addProtocol(url))
+    // If it ends with .html/.node/.php/.net/.etc, don’t need to add /
+    if (/\.(\w+)$/.test(pathname)) {
+      return `${origin}${pathname}${search}`
     }
     const fullPath = `${origin}${pathname}/`.replace(/\/\/$/, '/')
-    return /^https?:\/\//.test(fullPath) ? fullPath : ''
+    return /^https?:\/\//.test(fullPath) ? `${fullPath}${search}` : ''
   } catch (e) {
     console.error('[micro-app]', e)
     return ''

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -89,7 +89,7 @@ export function getEffectivePath (url: string): string {
     return pathArr.join('/') + '/'
   }
 
-  return url
+  return `${origin}${pathname}/`.replace(/\/\/$/, '/')
 }
 
 /**

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -81,9 +81,10 @@ export function formatURL (url: string | null): string {
  * @param url app.url
  */
 export function getEffectivePath (url: string): string {
-  const { pathname } = new URL(addProtocol(url))
+  const { origin, pathname } = new URL(url)
   if (/\.(\w+)$/.test(pathname)) {
-    const pathArr = url.split('/')
+    const fullPath = `${origin}${pathname}`
+    const pathArr = fullPath.split('/')
     pathArr.pop()
     return pathArr.join('/') + '/'
   }

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -81,7 +81,7 @@ export function formatURL (url: string | null): string {
  * @param url app.url
  */
 export function getEffectivePath (url: string): string {
-  if (/\.html$/.test(url)) {
+  if (/\.(\w+)$/.test(url)) {
     const pathArr = url.split('/')
     pathArr.pop()
     return pathArr.join('/') + '/'

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -81,7 +81,8 @@ export function formatURL (url: string | null): string {
  * @param url app.url
  */
 export function getEffectivePath (url: string): string {
-  if (/\.(\w+)$/.test(url)) {
+  const { pathname } = new URL(addProtocol(url))
+  if (/\.(\w+)$/.test(pathname)) {
     const pathArr = url.split('/')
     pathArr.pop()
     return pathArr.join('/') + '/'


### PR DESCRIPTION
目前诸如.node/.php/.net等后缀的URL没有兼容，我司历史技术选型原因，有很多采用.node服务端渲染的页面，目前被自动加上了/，导致无法正常访问，希望尽快解决一下