### PR TITLE
fix svg style with fill: url(#ID_1_2) not working

### DIFF
--- a/src/source/scoped_css.ts
+++ b/src/source/scoped_css.ts
@@ -53,7 +53,7 @@ function scopedHost (
   linkpath?: string,
 ) {
   return cssText.replace(/url\(["']?([^)"']+)["']?\)/gm, (all, $1) => {
-    if (/^(data|blob):/.test($1)) {
+    if (/^(data|blob):|#/.test($1)) {
       return all
     } else if (/^(https?:)?\/\//.test($1)) {
       if (isSafari()) {


### PR DESCRIPTION
SVG 图标通过 `fill: url(#ID_X_Y)` 的样式来填充渲染时, 因为补全了 `baseURI` 导致找不到对应元素

![image](https://user-images.githubusercontent.com/13565030/147718235-9ef8fa43-16d5-41b1-ac86-900d330c7b16.png)
