### PR TITLE
feat: Compat with SSG rendering mode by suffix and dynamically adapt to the  baseroute of the child application

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,7 @@
 export enum ObservedAttrName {
   NAME = 'name',
   URL = 'url',
+  SUFFIX = 'suffix',
 }
 
 // app status

--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -37,6 +37,7 @@ export interface CreateAppParam {
   inline?: boolean
   baseroute?: string
   container?: HTMLElement | ShadowRoot
+  suffix?: string
 }
 
 export default class CreateApp implements AppInterface {
@@ -60,6 +61,7 @@ export default class CreateApp implements AppInterface {
   baseroute = ''
   source: sourceType
   sandBox: SandBoxInterface | null = null
+  suffix = ''
 
   constructor ({
     name,
@@ -71,6 +73,7 @@ export default class CreateApp implements AppInterface {
     useSandbox,
     macro,
     baseroute,
+    suffix,
   }: CreateAppParam) {
     this.container = container ?? null
     this.inline = inline ?? false
@@ -86,6 +89,7 @@ export default class CreateApp implements AppInterface {
       links: new Map<string, sourceLinkInfo>(),
       scripts: new Map<string, sourceScriptInfo>(),
     }
+    this.suffix = suffix || ''
     this.loadSourceCode()
     this.useSandbox && (this.sandBox = new SandBox(name, url, this.macro))
   }

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -345,7 +345,7 @@ export function defineElement (tagName: string): void {
     private preProcessingUrl (url: string): string {
       const baseRoute = this.getBaseRouteCompatible()
       // Support to fetch SSR multi-page projects - by awesomedevin
-      const res = `${url}${this.suffix}`
+      const res = `${url}`
       return this.getDisposeResult('autoRoute') && baseRoute ? res.replace(baseRoute, '') : res
     }
 

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -85,7 +85,8 @@ export function defineElement (tagName: string): void {
           this.appName,
           lifeCycles.CREATED,
         )
-        patchHistoryMethods.call(this, this.appName)
+
+        this.getDisposeResult('autoRoute') && patchHistoryMethods.call(this, this.appName)
       })
 
       this.initialMount()
@@ -345,7 +346,7 @@ export function defineElement (tagName: string): void {
       const baseRoute = this.getBaseRouteCompatible()
       // Support to fetch SSR multi-page projects - by awesomedevin
       const res = `${url}${this.suffix}`
-      return this.getDisposeResult('autoRoute') && baseRoute && this.getDisposeResult('ssr') ? res.replace(baseRoute, '') : res
+      return this.getDisposeResult('autoRoute') && baseRoute ? res.replace(baseRoute, '') : res
     }
 
     // create app instance

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -345,7 +345,7 @@ export function defineElement (tagName: string): void {
       const baseRoute = this.getBaseRouteCompatible()
       // Support to fetch SSR multi-page projects - by awesomedevin
       const res = `${url}${this.suffix}`
-      return baseRoute && this.getDisposeResult('ssr') ? res.replace(baseRoute, '') : res
+      return this.getDisposeResult('autoRoute') && baseRoute && this.getDisposeResult('ssr') ? res.replace(baseRoute, '') : res
     }
 
     // create app instance

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -337,6 +337,13 @@ export function defineElement (tagName: string): void {
       ))
     }
 
+    private preProcessingUrl (url: string): string {
+      const baseRoute = this.getBaseRouteCompatible()
+      // Support to fetch SSR multi-page projects - by awesomedevin
+      const res = `${url}${this.suffix}`
+      return baseRoute ? res.replace(baseRoute, '') : res
+    }
+
     // create app instance
     private handleCreateApp (): void {
       /**
@@ -349,8 +356,8 @@ export function defineElement (tagName: string): void {
 
       const instance: AppInterface = new CreateApp({
         name: this.appName,
-        url: this.appUrl,
-        ssrUrl: this.ssrUrl,
+        url: this.getDisposeResult('autoRoute') ? this.preProcessingUrl(this.appUrl) : this.appUrl,
+        ssrUrl: this.getDisposeResult('autoRoute') ? this.preProcessingUrl(this.ssrUrl) : this.ssrUrl,
         container: this.shadowRoot ?? this,
         inline: this.getDisposeResult('inline'),
         scopecss: !(this.getDisposeResult('disableScopecss') || this.getDisposeResult('shadowDOM')),

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -29,6 +29,7 @@ import {
 import microApp from './micro_app'
 import dispatchLifecyclesEvent from './interact/lifecycles_event'
 import globalEnv from './libs/global_env'
+import { patchHistoryMethods } from './source'
 
 // record all micro-app elements
 export const elementInstanceMap = new Map<Element, boolean>()
@@ -78,11 +79,14 @@ export function defineElement (tagName: string): void {
         this.performWhenFirstCreated()
       }
 
-      defer(() => dispatchLifecyclesEvent(
-        this,
-        this.appName,
-        lifeCycles.CREATED,
-      ))
+      defer(() => {
+        dispatchLifecyclesEvent(
+          this,
+          this.appName,
+          lifeCycles.CREATED,
+        )
+        patchHistoryMethods.call(this, this.appName)
+      })
 
       this.initialMount()
     }

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -345,7 +345,7 @@ export function defineElement (tagName: string): void {
       const baseRoute = this.getBaseRouteCompatible()
       // Support to fetch SSR multi-page projects - by awesomedevin
       const res = `${url}${this.suffix}`
-      return baseRoute ? res.replace(baseRoute, '') : res
+      return baseRoute && this.getDisposeResult('ssr') ? res.replace(baseRoute, '') : res
     }
 
     // create app instance
@@ -360,8 +360,8 @@ export function defineElement (tagName: string): void {
 
       const instance: AppInterface = new CreateApp({
         name: this.appName,
-        url: this.getDisposeResult('autoRoute') ? this.preProcessingUrl(this.appUrl) : this.appUrl,
-        ssrUrl: this.getDisposeResult('autoRoute') ? this.preProcessingUrl(this.ssrUrl) : this.ssrUrl,
+        url: this.preProcessingUrl(this.appUrl),
+        ssrUrl: this.preProcessingUrl(this.ssrUrl),
         container: this.shadowRoot ?? this,
         inline: this.getDisposeResult('inline'),
         scopecss: !(this.getDisposeResult('disableScopecss') || this.getDisposeResult('shadowDOM')),

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -106,7 +106,7 @@ export function defineElement (tagName: string): void {
     }
 
     attributeChangedCallback (attr: ObservedAttrName, _oldVal: string, newVal: string): void {
-      const attrMap = {
+      const attrMap: {[key: string] : 'appName' | 'appUrl' | 'suffix' } = {
         [ObservedAttrName.NAME]: 'appName',
         [ObservedAttrName.URL]: 'appUrl',
         [ObservedAttrName.SUFFIX]: 'suffix',

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -96,7 +96,7 @@ function extractSourceDom (htmlStr: string, app: AppInterface) {
  * @param app app
  */
 export default function extractHtml (app: AppInterface): void {
-  fetchSource(app.ssrUrl || app.url, app.name, { cache: 'no-cache' }).then((htmlStr: string) => {
+  fetchSource(`${app.ssrUrl || app.url}${app.suffix}`, app.name, { cache: 'no-cache' }).then((htmlStr: string) => {
     if (!htmlStr) {
       const msg = 'html is empty, please check in detail'
       app.onerror(new Error(msg))

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -54,6 +54,7 @@ declare module '@micro-app/types' {
     source: sourceType // sources of css, js, html
     sandBox: SandBoxInterface | null // sanxbox
     umdMode: boolean // is umd mode
+    suffix?: string
 
     // Load resources
     loadSourceCode (): void

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -103,7 +103,7 @@ declare module '@micro-app/types' {
     disconnectedCallback (): void
 
     // Hooks for element attributes change
-    attributeChangedCallback (a: 'name' | 'url', o: string, n: string): void
+    attributeChangedCallback (a: 'name' | 'url' | 'suffix', o: string, n: string): void
   }
 
   type prefetchParam = {


### PR DESCRIPTION
1. 新增参数suffix，兼容ssg渲染模式 。
2. 新增 autoRoute 参数，支持从框架层面通过 autoRoute 动态兼容子应用路由存在 baseroute 的情况，子应用无需处理，不传该参数则子应用需要做处理
示例如下：
```html
<micro-app suffix=".html" autoRoute />
```