### PR TITLE
feat: support to inherit the style of <micro-app> tag

### DIFF
--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -90,6 +90,14 @@ export default class CreateApp implements AppInterface {
     this.useSandbox && (this.sandBox = new SandBox(name, url, this.macro))
   }
 
+  // Async css from App
+  asyncStyleFromAppTag (microAppBody: HTMLElement): void {
+    const appTag = Array.from(document.body.getElementsByTagName('micro-app')).find(item => item.getAttribute('name') === this.name)
+    if (!appTag) return
+    const appTagStyle = (appTag as HTMLElement).style.cssText
+    microAppBody.style.cssText = appTagStyle
+  }
+
   // Load resources
   loadSourceCode (): void {
     this.state = appStates.LOADING_SOURCE_CODE

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -74,6 +74,8 @@ function extractSourceDom (htmlStr: string, app: AppInterface) {
     app.onerror(new Error(msg))
     return logError(msg, app.name)
   }
+  // Async CSS - by awesomedevin
+  app.asyncStyleFromAppTag(microAppBody as HTMLBodyElement)
 
   flatChildren(wrapElement, app, microAppHead)
 

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -64,6 +64,9 @@ declare module '@micro-app/types' {
     // Error loading HTML
     onLoadError (e: Error): void
 
+    // sync style
+    asyncStyleFromAppTag(microAppBody: HTMLElement): void
+
     // mount app
     mount (
       container?: HTMLElement | ShadowRoot,


### PR DESCRIPTION
支持继承<micro-app>样式给子应用，以兼容子应用 flex 布局或其他情况。
示例代码如下：

```html
<micro-app style={{ width: '100%', height: '100vh' }} />
```