### PR TITLE
feat: support to inherit the meta tag of the child application

### DIFF
--- a/src/micro_app.ts
+++ b/src/micro_app.ts
@@ -1,4 +1,4 @@
-import type { OptionsType, MicroAppConfigType, lifeCyclesType, plugins, fetchType } from '@micro-app/types'
+import type { OptionsType, MicroAppConfigType, lifeCyclesType, plugins, fetchType, effectiveMetas } from '@micro-app/types'
 import { defineElement } from './micro_app_element'
 import preFetch, { getGlobalAssets } from './prefetch'
 import { logError, logWarn, isFunction, isBrowser, isPlainObject, formatAppName } from './libs/utils'
@@ -75,6 +75,11 @@ class MicroApp extends EventCenterForBaseApp implements MicroAppConfigType {
         }
 
         this.plugins = options.plugins
+      }
+
+      // 新增effectiveMeta 配置 - by awesomedevin
+      if (isPlainObject(options.effectiveMetas)) {
+        this.effectiveMetas = options.effectiveMetas
       }
     }
 

--- a/src/micro_app.ts
+++ b/src/micro_app.ts
@@ -16,6 +16,7 @@ class MicroApp extends EventCenterForBaseApp implements MicroAppConfigType {
   ssr?: boolean
   lifeCycles?: lifeCyclesType
   plugins?: plugins
+  effectiveMetas?: effectiveMetas
   fetch?: fetchType
   preFetch = preFetch
   start (options?: OptionsType) {

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -2,8 +2,9 @@ import type { AppInterface } from '@micro-app/types'
 import { fetchSource } from './fetch'
 import { logError, CompletionPath, pureCreateElement } from '../libs/utils'
 import { extractLinkFromHtml, fetchLinksFromHtml } from './links'
-import { extractScriptElement, fetchScriptsFromHtml } from './scripts'
+import { extractScriptElement, fetchScriptsFromHtml, useEffectiveMetas } from './scripts'
 import scopedCSS from './scoped_css'
+import microApp from '../micro_app'
 
 /**
  * transform html string to dom
@@ -68,6 +69,17 @@ function extractSourceDom (htmlStr: string, app: AppInterface) {
   const wrapElement = getWrapElement(htmlStr)
   const microAppHead = wrapElement.querySelector('micro-app-head')
   const microAppBody = wrapElement.querySelector('micro-app-body')
+
+  // Effective meta tag of child App
+  const microMetas = microApp.effectiveMetas ? useEffectiveMetas(Array.from(wrapElement.getElementsByTagName('meta')), app.name, microApp.effectiveMetas) : []
+
+  // append meta Tag
+  if (microMetas.length) {
+    const rootHead = document.getElementsByTagName('head')[0]
+    for (const microMeta of microMetas) {
+      rootHead.appendChild(microMeta)
+    }
+  }
 
   if (!microAppHead || !microAppBody) {
     const msg = `element ${microAppHead ? 'body' : 'head'} is missing`

--- a/src/source/scripts.ts
+++ b/src/source/scripts.ts
@@ -4,6 +4,7 @@ import type {
   sourceScriptInfo,
   plugins,
   Func,
+  effectiveMetas,
 } from '@micro-app/types'
 import { fetchSource } from './fetch'
 import {

--- a/src/source/scripts.ts
+++ b/src/source/scripts.ts
@@ -397,3 +397,20 @@ function usePlugins (url: string, code: string, appName: string, plugins: plugin
 
   return code
 }
+
+/**
+ * Call the efftiveMeta to process the dom - by awesomedevin
+ * @param appName app name
+ * @param efftiveMeta efftiveMeta
+ */
+export function useEffectiveMetas (metas: HTMLMetaElement[], appName: string, efftiveMetas: effectiveMetas): HTMLMetaElement[] {
+  if (efftiveMetas?.global && isFunction(efftiveMetas.global)) {
+    return efftiveMetas.global(metas)
+  }
+  if (efftiveMetas?.modules && isPlainObject(efftiveMetas.modules)) {
+    if (efftiveMetas.modules[appName] && isFunction(efftiveMetas.modules[appName])) {
+      return efftiveMetas.modules[appName](metas)
+    }
+  }
+  return []
+}

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -115,6 +115,13 @@ declare module '@micro-app/types' {
     shadowDOM?: boolean
   }
 
+  type effectiveMetas = {
+    global: (metas: HTMLMetaElement[]) => HTMLMetaElement[]
+    modules: {
+      [name: string]: (metas: HTMLMetaElement[]) => HTMLMetaElement[]
+    }
+  }
+
   // prefetch params
   type prefetchParamList = Array<prefetchParam> | (() => Array<prefetchParam>)
 
@@ -173,6 +180,7 @@ declare module '@micro-app/types' {
     ssr?: boolean
     lifeCycles?: lifeCyclesType
     preFetchApps?: prefetchParamList
+    effectiveMetas?: effectiveMetas
     plugins?: plugins
     fetch?: fetchType
     globalAssets?: globalAssetsType,
@@ -210,10 +218,3 @@ declare module '@micro-zoe/micro-app/polyfill/jsx-custom-event'
 declare const __DEV__: boolean
 
 declare const __TEST__: boolean
-
-type effectiveMetas = {
-  global: (metas: HTMLMetaElement[]) => HTMLMetaElement[]
-  modules: {
-    [name: string]: (metas: HTMLMetaElement[]) => HTMLMetaElement[]
-  }
-}

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -210,3 +210,10 @@ declare module '@micro-zoe/micro-app/polyfill/jsx-custom-event'
 declare const __DEV__: boolean
 
 declare const __TEST__: boolean
+
+type effectiveMetas = {
+  global: (metas: HTMLMetaElement[]) => HTMLMetaElement[]
+  modules: {
+    [name: string]: (metas: HTMLMetaElement[]) => HTMLMetaElement[]
+  }
+}


### PR DESCRIPTION
支持自定义继承子应用的meta标签，支持对全局子应用或单个子应用进行配置，使用方式可参考plugin
示例代码如下：
```javascript
microApp.start({
  effectiveMetas: {
    global (metas: HTMLMetaElement[]) {
      return Array.from(metas).filter(item => true)
    },
  },
})
```