### PR TITLE
fix: 子應用內 `position: absolute` 預設會參考到主應用的 body。對 `Element.prototype.getBoundingClientRect` 進行 patch

### DIFF
--- a/src/libs/global_env.ts
+++ b/src/libs/global_env.ts
@@ -54,6 +54,7 @@ export function initGlobalEnv (): void {
     const rawAppend = Element.prototype.append
     const rawPrepend = Element.prototype.prepend
     const rawCloneNode = Element.prototype.cloneNode
+    const rawGetBoundingClientRect = Element.prototype.getBoundingClientRect
 
     const rawCreateElement = Document.prototype.createElement
     const rawCreateElementNS = Document.prototype.createElementNS
@@ -104,6 +105,7 @@ export function initGlobalEnv (): void {
       rawAppend,
       rawPrepend,
       rawCloneNode,
+      rawGetBoundingClientRect,
       rawCreateElement,
       rawCreateElementNS,
       rawCreateDocumentFragment,

--- a/src/source/patch.ts
+++ b/src/source/patch.ts
@@ -461,7 +461,7 @@ export function rejectMicroAppStyle (): void {
     hasRejectMicroAppStyle = true
     const style = pureCreateElement('style')
     globalEnv.rawSetAttribute.call(style, 'type', 'text/css')
-    style.textContent = `\n${microApp.tagName}, micro-app-body { display: block; } \nmicro-app-head { display: none; }`
+    style.textContent = `\n${microApp.tagName}, micro-app-body { display: block; position: relative; } \nmicro-app-head { display: none; }`
     globalEnv.rawDocument.head.appendChild(style)
   }
 }

--- a/src/source/patch.ts
+++ b/src/source/patch.ts
@@ -259,6 +259,28 @@ export function patchElementPrototypeMethods (): void {
     this.__MICRO_APP_NAME__ && (clonedNode.__MICRO_APP_NAME__ = this.__MICRO_APP_NAME__)
     return clonedNode
   }
+
+  // patch getBoundingClientRect
+  Element.prototype.getBoundingClientRect = function getBoundingClientRect () {
+    const appName = getCurrentAppName()
+    const rawRect: DOMRect = globalEnv.rawGetBoundingClientRect.call(this)
+    if (!appName) {
+      return rawRect
+    }
+    const app = appInstanceMap.get(appName)
+    if (!app?.container) {
+      return rawRect
+    }
+    const appBody = app.container.querySelector('micro-app-body')
+    const appBodyRect: DOMRect = globalEnv.rawGetBoundingClientRect.call(appBody)
+    const computedRect: DOMRect = new DOMRect(
+      rawRect.x - appBodyRect.x,
+      rawRect.y - appBodyRect.y,
+      rawRect.width,
+      rawRect.height,
+    )
+    return computedRect
+  }
 }
 
 /**


### PR DESCRIPTION
1. 修正子應用內 `position: absolute` 預設會參考到主應用的 body
    - 會造成子應用內的元素像是逃離了容器
2. 修正 `Element.prototype.getBoundingClientRect` 計算出的是主應用窗口的位置
    - ElementUI 中所使用到的 popper 功能（el-tooltip）計算元素位置時會使用 `getBoundingClientRect`，在子應用中會造成取得仍然是主應用窗口位置導致子應用生成元素在錯誤的位置

這個項目挺棒的！感謝開源！