### PR TITLE
feat: provide source script info for js loader

### DIFF
--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -136,7 +136,7 @@ declare module '@micro-app/types' {
       // options for plugin as the third parameter of loader
       options?: unknown
       // handle function
-      loader?: (code: string, url: string, options: unknown) => string
+      loader?: (code: string, url: string, options: unknown, info: sourceScriptInfo) => string
     }>
 
     // plugin for special app
@@ -149,7 +149,7 @@ declare module '@micro-app/types' {
         // options for plugin as the third parameter of loader
         options?: unknown
         // handle function
-        loader?: (code: string, url: string, options: unknown) => string
+        loader?: (code: string, url: string, options: unknown, info: sourceScriptInfo) => string
       }>
     }
   }


### PR DESCRIPTION
```ts
microApp.start({
  plugins: {
    global: {
      loader?: (code: string, url: string, options: any, info: sourceScriptInfo) => code
    },
  },
})

```

在执行loader的时候可以获取到更多脚本标签信息，可以实现更加细化的loader逻辑