### PR TITLE
feat: 增加disableBlob全局或实例选项,可选使用blob

### DIFF
--- a/src/__tests__/create_app.test.ts
+++ b/src/__tests__/create_app.test.ts
@@ -478,6 +478,24 @@ describe('create_app', () => {
     })
   })
 
+  // 关闭Blob
+  test('disableBlob in this app', async () => {
+    const microAppElement2 = document.createElement('micro-app')
+    microAppElement2.setAttribute('name', 'test-app21')
+    microAppElement2.setAttribute('url', `http://127.0.0.1:${ports.create_app}/dynamic/`)
+    microAppElement2.setAttribute('disableBlob', 'true')
+
+    appCon.appendChild(microAppElement2)
+    await new Promise((resolve) => {
+      microAppElement2.addEventListener('mounted', () => {
+        expect(appInstanceMap.get('test-app21')!.useBlob).toBeFalsy()
+        resolve(true)
+      }, false)
+    })
+
+    appCon.removeChild(microAppElement2)
+  })
+
   // 测试getActiveApps方法
   test('test getActiveApps method', async () => {
     // 因为上面已经执行unmountAllApps卸载了所有应用，所以这里长度为0

--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -32,6 +32,7 @@ export interface CreateAppParam {
   url: string
   ssrUrl?: string
   scopecss: boolean
+  useBlob?: boolean
   useSandbox: boolean
   inline?: boolean
   baseroute?: string
@@ -55,6 +56,7 @@ export default class CreateApp implements AppInterface {
   container: HTMLElement | ShadowRoot | null = null
   inline: boolean
   scopecss: boolean
+  useBlob: boolean
   useSandbox: boolean
   baseroute = ''
   source: sourceType
@@ -67,6 +69,7 @@ export default class CreateApp implements AppInterface {
     container,
     inline,
     scopecss,
+    useBlob,
     useSandbox,
     baseroute,
   }: CreateAppParam) {
@@ -78,6 +81,7 @@ export default class CreateApp implements AppInterface {
     this.name = name
     this.url = url
     this.useSandbox = useSandbox
+    this.useBlob = useBlob ?? true
     this.scopecss = this.useSandbox && scopecss
     this.source = {
       links: new Map<string, sourceLinkInfo>(),

--- a/src/micro_app.ts
+++ b/src/micro_app.ts
@@ -121,6 +121,7 @@ export class MicroApp extends EventCenterForBaseApp implements MicroAppConfigTyp
   inline?: boolean
   disableScopecss?: boolean
   disableSandbox?: boolean
+  disableBlob?: boolean
   ssr?: boolean
   lifeCycles?: lifeCyclesType
   plugins?: plugins
@@ -155,6 +156,7 @@ export class MicroApp extends EventCenterForBaseApp implements MicroAppConfigTyp
       // @ts-ignore
       this.destory = options.destory
       this.inline = options.inline
+      this.disableBlob = options.disableBlob
       this.disableScopecss = options.disableScopecss
       this.disableSandbox = options.disableSandbox
       this.ssr = options.ssr

--- a/src/micro_app_element.ts
+++ b/src/micro_app_element.ts
@@ -308,6 +308,7 @@ export function defineElement (tagName: string): void {
         container: this.shadowRoot ?? this,
         inline: this.getDisposeResult('inline'),
         scopecss: !(this.getDisposeResult('disableScopecss') || this.getDisposeResult('shadowDOM')),
+        useBlob: !this.getDisposeResult('disableBlob'),
         useSandbox: !this.getDisposeResult('disableSandbox'),
         baseroute: this.getBaseRouteCompatible(),
       })

--- a/src/source/scripts.ts
+++ b/src/source/scripts.ts
@@ -241,7 +241,7 @@ export function runScript (
     const code = bindScope(url, app, info.code, info.module)
     if (app.inline || info.module) {
       const scriptElement = pureCreateElement('script')
-      runCode2InlineScript(url, code, info.module, scriptElement, callback)
+      runCode2InlineScript(url, code, info.module, app.useBlob, scriptElement, callback)
       if (isDynamic) return scriptElement
       // TEST IGNORE
       app.container?.querySelector('micro-app-body')!.appendChild(scriptElement)
@@ -298,7 +298,7 @@ export function runDynamicRemoteScript (
     try {
       code = bindScope(url, app, code, info.module)
       if (app.inline || info.module) {
-        runCode2InlineScript(url, code, info.module, replaceElement as HTMLScriptElement, dispatchScriptOnLoadEvent)
+        runCode2InlineScript(url, code, info.module, app.useBlob, replaceElement as HTMLScriptElement, dispatchScriptOnLoadEvent)
       } else {
         runCode2Function(code, info)
       }
@@ -326,13 +326,18 @@ function runCode2InlineScript (
   url: string,
   code: string,
   module: boolean,
+  useBlob: boolean,
   scriptElement: HTMLScriptElement,
   callback?: moduleCallBack,
 ): void {
   if (module) {
     // module script is async, transform it to a blob for subsequent operations
-    const blob = new Blob([code], { type: 'text/javascript' })
-    scriptElement.src = URL.createObjectURL(blob)
+    if (useBlob) {
+      const blob = new Blob([code], { type: 'text/javascript' })
+      scriptElement.src = URL.createObjectURL(blob)
+    } else {
+      scriptElement.src = url
+    }
     scriptElement.setAttribute('type', 'module')
     if (callback) {
       callback.moduleCount && callback.moduleCount--

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -49,6 +49,7 @@ declare module '@micro-app/types' {
     container: HTMLElement | ShadowRoot | null // container maybe null, micro-app, shadowRoot, DIV(keep-alive)
     inline: boolean //  whether js runs in inline script mode, default is false
     scopecss: boolean // whether use css scoped, default is true
+    useBlob: boolean // whether use blob to load js, default is true
     useSandbox: boolean // whether use js sandbox, default is true
     baseroute: string // route prefix, default is ''
     source: sourceType // sources of css, js, html
@@ -166,6 +167,7 @@ declare module '@micro-app/types' {
     shadowDOM?: boolean
     destroy?: boolean
     inline?: boolean
+    disableBlob?: boolean
     disableScopecss?: boolean
     disableSandbox?: boolean
     ssr?: boolean


### PR DESCRIPTION
由于使用blob会导致 vite 应用二次加载相同的依赖，
所以增加 disableBlob 配置项，可以在全局或者局部 micro-app 标签使用，默认启用

Because using blob will cause vite applications to load the same dependencies twice,
Therefore, add the _disableblob_ configuration item, which can be used in the global or local micro app tags. It is enabled by default

`<micro-app
      name='vite'
      url='http://localhost:7001/micro-app/vite/'
      inline
      disableBlob
      disableSandbox
    >`


`microApp.start({
  disableBlob: true
})`

and： 新增关闭测试用例
所有测试用例已通过


Add close test case