### PR TITLE
feat: 新增 video、audio、source、embed 标签 src 自动补全

### DIFF
--- a/src/source/patch.ts
+++ b/src/source/patch.ts
@@ -552,7 +552,7 @@ export function patchSetAttribute (): void {
         appName &&
         appInstanceMap.has(appName) &&
         (
-          ((key === 'src' || key === 'srcset') && /^(img|script)$/i.test(this.tagName)) ||
+          ((key === 'src' || key === 'srcset') && /^(img|script|video|audio|source|embed)$/i.test(this.tagName)) ||
           (key === 'href' && /^link$/i.test(this.tagName))
         )
       ) {


### PR DESCRIPTION
视频、音频属资源类文件，应该需要享受补全路径使其正常加载。