### PR TITLE
fix: 修复低版本浏览器不支持 String.prototype.replaceAll 的问题

### DIFF
--- a/src/source/links.ts
+++ b/src/source/links.ts
@@ -37,7 +37,7 @@ function getExistParseCode (
     if (item !== appName) {
       const appSpaceData = appSpace[item]
       if (appSpaceData.parsedCode) {
-        return appSpaceData.parsedCode.replaceAll(new RegExp(createPrefix(item, true), 'g'), prefix)
+        return appSpaceData.parsedCode.replace(new RegExp(createPrefix(item, true), 'g'), prefix)
       }
     }
   }


### PR DESCRIPTION
看到代码中的正则已经加了g参数，和 replaceAll 效果是一样的，但是 replaceAll 在低版本浏览器上有兼容性问题，希望可以采用兼容性更好的写法