### PR TITLE
fix: custom properties in iframe sandbox return the value directly without binding this

### DIFF
--- a/src/sandbox/iframe/index.ts
+++ b/src/sandbox/iframe/index.ts
@@ -416,6 +416,8 @@ export default class IframeSandbox {
 
   private createProxyWindow (microAppWindow: microAppWindowType): void {
     const rawWindow = globalEnv.rawWindow
+    const customProperties: PropertyKey[] = []
+
     return new Proxy(microAppWindow, {
       get: (target: microAppWindowType, key: PropertyKey): unknown => {
         if (key === 'location') {
@@ -424,6 +426,10 @@ export default class IframeSandbox {
 
         if (globalPropertyList.includes(key.toString())) {
           return this.proxyWindow
+        }
+
+        if (customProperties.includes(key)) {
+          return Reflect.get(target, key)
         }
 
         return bindFunctionToRawTarget(Reflect.get(target, key), target)
@@ -436,6 +442,10 @@ export default class IframeSandbox {
          */
         if (key === 'location') {
           return Reflect.set(rawWindow, key, value)
+        }
+
+        if (!Reflect.has(target, key)) {
+          customProperties.push(key)
         }
 
         Reflect.set(target, key, value)


### PR DESCRIPTION
https://github.com/micro-zoe/micro-app/blob/b85c6ad78d3f6ee455a4c933a5ae731c6fca55a9/src/sandbox/iframe/index.ts#L420-L430

429 行中，如果从 proxyWindow 获取一个方法，获取了方法之后调用 apply 方法修改了 this 指向，因为这里获取之前提前调用了 bind 方法修改了 this 指向，导致后续获取到方法之后再调用 apply 方法就没有用了，导致报错。

https://github.com/micro-zoe/micro-app/blob/b85c6ad78d3f6ee455a4c933a5ae731c6fca55a9/src/sandbox/with/index.ts#L394-L403

在 with 沙箱中，target 是一个不同于 window 的额外对象，若用户自定义的属性值设置到 window 上时，会设置到这个对象上。所以在 with 沙箱中，用户自己设置的方法会直接返回而不会绑定this 为 window。

为了和 with 沙箱保持一致，用户自定义的 window 属性在 IFrame 沙箱中也应该直接返回而不绑定 this。