### PR TITLE
feat: patch createComment method for iframe sandbox

### DIFF
--- a/src/libs/global_env.ts
+++ b/src/libs/global_env.ts
@@ -92,6 +92,7 @@ export function initGlobalEnv (): void {
     const rawCreateElementNS = rawRootDocument.prototype.createElementNS
     const rawCreateDocumentFragment = rawRootDocument.prototype.createDocumentFragment
     const rawCreateTextNode = rawRootDocument.prototype.createTextNode
+    const rawCreateComment = rawRootDocument.prototype.createComment
     const rawQuerySelector = rawRootDocument.prototype.querySelector
     const rawQuerySelectorAll = rawRootDocument.prototype.querySelectorAll
     const rawGetElementById = rawRootDocument.prototype.getElementById
@@ -150,6 +151,7 @@ export function initGlobalEnv (): void {
       rawCreateElementNS,
       rawCreateDocumentFragment,
       rawCreateTextNode,
+      rawCreateComment,
       rawQuerySelector,
       rawQuerySelectorAll,
       rawGetElementById,

--- a/src/sandbox/iframe/document.ts
+++ b/src/sandbox/iframe/document.ts
@@ -50,6 +50,7 @@ function patchDocumentPrototype (appName: string, microAppWindow: microAppWindow
   const microDocument = microAppWindow.document
   const rawMicroCreateElement = microRootDocument.prototype.createElement
   const rawMicroCreateTextNode = microRootDocument.prototype.createTextNode
+  const rawMicroCreateComment = microRootDocument.prototype.createComment
   const rawMicroQuerySelector = microRootDocument.prototype.querySelector
   const rawMicroQuerySelectorAll = microRootDocument.prototype.querySelectorAll
   const rawMicroGetElementById = microRootDocument.prototype.getElementById
@@ -68,6 +69,11 @@ function patchDocumentPrototype (appName: string, microAppWindow: microAppWindow
   microRootDocument.prototype.createTextNode = function createTextNode (data: string): Text {
     const element = rawMicroCreateTextNode.call(this, data)
     return updateElementInfo<Text>(element, appName)
+  }
+
+  microRootDocument.prototype.createComment = function createComment (data: string): Comment {
+    const element = rawMicroCreateComment.call(this, data)
+    return updateElementInfo<Comment>(element, appName)
   }
 
   function getDefaultRawTarget (target: Document): Document {

--- a/src/source/patch.ts
+++ b/src/source/patch.ts
@@ -585,6 +585,11 @@ function patchDocument () {
   //   return markElement(element)
   // }
 
+  rawRootDocument.prototype.createComment = function createComment (data: string): Comment {
+    const element = globalEnv.rawCreateComment.call(getBindTarget(this), data)
+    return markElement(element)
+  }
+
   // query element👇
   function querySelector (this: Document, selectors: string): any {
     const _this = getBindTarget(this)


### PR DESCRIPTION
在 `iframe` 沙箱环境下执行 `insertBofore` 会报错：

```ts
const refChild = el // micro-app-body 下的一个子元素
const comment = document.createComment('v-if')
document.body.insertBefore(comment, refChild) // 报错 DOMException: Failed to execute 'insertBefore' on 'Node': The node before which the new node is to be inserted is not a child of this node.
 
```

由于 `document.body` 拿到的是基座的 `body`，而 `refChild` 是 `micro-app-body` 下的子元素，此时由于 `comment` 元素上不存在 `__MICRO_APP_NAME__` 属性，所以会直接调用基座 `body` 元素上的 `insertBofre` 方法，而 `refChild` 不是 `body` 的子元素而是 `micro-app-body` 的子元素，因此会报错。