### PR TITLE
fix: selection data can't be retrieved in the iframe sandbox

### DIFF
--- a/src/sandbox/iframe/special_key.ts
+++ b/src/sandbox/iframe/special_key.ts
@@ -14,6 +14,8 @@ export const escape2RawWindowRegExpKeys = [
   /height$|width$/i,
   /offset$/i,
   // /event$/i,
+  /selection$/i,
+  /^range/i,
   /^screen/i,
   /^scroll/i,
   /X$|Y$/,
@@ -53,6 +55,7 @@ export const proxy2RawDocOrShadowMethods = [
   'append',
   'contains',
   'replaceChildren',
+  'createRange', // 普通元素没有 -- document或shadowRoot有
   'getSelection', // 普通元素没有 -- document或shadowRoot有
   'elementFromPoint', // 普通元素没有 -- document或shadowRoot有
   'elementsFromPoint', // 普通元素没有 -- document或shadowRoot有


### PR DESCRIPTION
1. 在 iframe 沙箱中使用 window.getSelection 无法正确获取到 Selection 数据，因此添加了 getSelection 的代理
2. 获取的 Selection 对象为基座的 Selection，所以在子应用中使用 `instanceof Selection` 值为 false，因此代理了基座了 `Selection` 对象。
3. Selection 存在 `getRangeAt` 方法，此方法返回的 Range 对象也是基座的 range 对象，此时 `instanceof Range` 会为 `false`，所以代理了 `Range`, `RangeError` 以及 `document.createRange`

- /selection$/i 会匹配到 `Selection`, `getSelection`
- /^range/i 会匹配到 `Range`, `RangeError`