### PR TITLE
fix: adapt to lower versions of typescript syntax

### DIFF
--- a/scripts/create_type.js
+++ b/scripts/create_type.js
@@ -54,6 +54,9 @@ function createDts () {
     if (isDirectory(typingsDir)) {
       addReference(typingsDir)
     }
+    const dtsCode = fs.readFileSync(outPath, 'utf-8')
+    const parsedCode = dtsCode.replace(/import type/g, 'import')
+    fs.writeFileSync(outPath, parsedCode)
   } catch (e) {
     console.log(
       chalk.red('生成*.d.ts文件失败'),


### PR DESCRIPTION
对于一些老项目，低版本的 TypeScript 不支持 `import type` 语法，编译会报错。如 `v3.5.3`

对于高版本的 `TypeScript`，不使用 `import type` 语法并不会存在问题。