### PR TITLE
fix: the iframe sandbox adds frameElement proxy to the RawWindow object

### DIFF
--- a/src/sandbox/iframe/special_key.ts
+++ b/src/sandbox/iframe/special_key.ts
@@ -19,6 +19,7 @@ export const escape2RawWindowRegExpKeys = [
   /^screen/i,
   /^scroll/i,
   /X$|Y$/,
+  /frameElement$/,
 ]
 
 export const uniqueDocumentElement = [


### PR DESCRIPTION
子应用中使用`frameElement`应该代理到 `RawWindow`

问题关联 #856 