### PR TITLE
fix: log error when mounting failed

### DIFF
--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -338,7 +338,10 @@ export default class CreateApp implements AppInterface {
       if (isPromise(umdHookMountResult)) {
         umdHookMountResult
           .then(() => this.dispatchMountedEvent())
-          .catch(() => this.dispatchMountedEvent())
+          .catch((e) => {
+            logError('An error occurred in window.mount \n', this.name, e)
+            this.dispatchMountedEvent()
+          })
       } else {
         this.dispatchMountedEvent()
       }


### PR DESCRIPTION
handleMounted 外部的 try-catch 语句无法捕获这里 Promise 的异常，这里没有任何输出，如果异步 mount 方法报错，这边会吃掉异常，没有任何打印但是应用无法正常启动，难以排查问题。