### PR TITLE
fix: fix iframe module incomptible with monaco

### DIFF
--- a/src/sandbox/iframe/document.ts
+++ b/src/sandbox/iframe/document.ts
@@ -65,6 +65,19 @@ function patchDocumentPrototype (appName: string, microAppWindow: microAppWindow
   const rawMicroGetElementsByClassName = microRootDocument.prototype.getElementsByClassName
   const rawMicroGetElementsByTagName = microRootDocument.prototype.getElementsByTagName
   const rawMicroGetElementsByName = microRootDocument.prototype.getElementsByName
+  const rawMicroElementFromPoint = microRootDocument.prototype.elementFromPoint
+  const rawMicroCaretRangeFromPoint = microRootDocument.prototype.caretRangeFromPoint
+
+  microRootDocument.prototype.caretRangeFromPoint = function caretRangeFromPoint (
+    x: number,
+    y: number,
+  ): Range {
+    // 这里this指向document才可以获取到子应用的document实例，range才可以被成功生成
+    const element = rawMicroElementFromPoint.call(document, x, y)
+    const range = rawMicroCaretRangeFromPoint.call(document, x, y)
+    updateElementInfo(element, appName)
+    return range
+  }
 
   microRootDocument.prototype.createElement = function createElement (
     tagName: string,


### PR DESCRIPTION
经过排查，发现monaco-editor,在micro-app的iframe模式下点击不了的原因是：
monaco-editor会调用document.caretRangeFromPoint这个方法，可是在主应用里面，这个方法执行的document对象并不是子应用的document，这就会造成monaco-editor无法成功创建Range，继而造成无法成功聚焦。主要修复：重写了iframe模式下的document.caretRangeFromPoint方法，让其指向了子应用的document。
具体描述在issue893 #893 
附上monaco-editor的源码：
![monaco源码](https://github.com/micro-zoe/micro-app/assets/83435945/883d7c20-475f-4952-b2ff-c01df6922775)
