### PR TITLE
fix: iframe sandbox element scope error

### DIFF
--- a/src/sandbox/iframe/document.ts
+++ b/src/sandbox/iframe/document.ts
@@ -11,6 +11,7 @@ import {
   logWarn,
   isUniqueElement,
   isInvalidQuerySelectorKey,
+  throttleDeferForSetAppName,
 } from '../../libs/utils'
 import globalEnv from '../../libs/global_env'
 import bindFunctionToRawTarget from '../bind_function'
@@ -256,7 +257,10 @@ function patchDocumentProperty (
     rawDefineProperty(microDocument, tagName, {
       enumerable: true,
       configurable: true,
-      get: () => rawDocument[tagName],
+      get: () => {
+        throttleDeferForSetAppName(appName)
+        return rawDocument[tagName]
+      },
       set: (value: unknown) => { rawDocument[tagName] = value },
     })
   })


### PR DESCRIPTION
在 iframe 沙箱中使用 `document.head.querySelector(...)` 会查询到基座应用的 `head` 标签内的元素。理论上应该查询的是 `micro-app-head` 中的元素