### PR TITLE
fix: ownerDocument value is incorrect when element inserted via user input

### DIFF
--- a/src/sandbox/adapter.ts
+++ b/src/sandbox/adapter.ts
@@ -128,10 +128,6 @@ export function updateElementInfo <T> (node: T, appName: string): T {
     })
 
     if (isIframeSandbox(appName)) {
-      rawDefineProperty(node, 'ownerDocument', {
-        configurable: true,
-        get: () => proxyWindow.document,
-      })
       /**
        * If HTML built-in node belongs to base app, it needs to be handled separately for parentNode
        * Fix error for nuxt@2.x + ElementUI@2.x

--- a/src/sandbox/iframe/element.ts
+++ b/src/sandbox/iframe/element.ts
@@ -54,6 +54,7 @@ function patchIframeNode (
   const rawMicroCloneNode = microRootNode.prototype.cloneNode
   const rawInnerHTMLDesc = Object.getOwnPropertyDescriptor(microRootElement.prototype, 'innerHTML') as PropertyDescriptor
   const rawParentNodeDesc = Object.getOwnPropertyDescriptor(microRootNode.prototype, 'parentNode') as PropertyDescriptor
+  const rawOwnerDocumentDesc = Object.getOwnPropertyDescriptor(microRootNode.prototype, 'ownerDocument') as PropertyDescriptor
 
   const isPureNode = (target: unknown): boolean | void => {
     return (isScriptElement(target) || isBaseElement(target)) && target.__PURE_ELEMENT__
@@ -152,6 +153,16 @@ function patchIframeNode (
     const clonedNode = rawMicroCloneNode.call(this, deep)
     return updateElementInfo(clonedNode, appName)
   }
+
+  rawDefineProperty(microRootNode.prototype, 'ownerDocument', {
+    configurable: true,
+    enumerable: true,
+    get () {
+      return this.__PURE_ELEMENT__
+        ? rawOwnerDocumentDesc.get!.call(this)
+        : microDocument
+    },
+  })
 
   rawDefineProperty(microRootElement.prototype, 'innerHTML', {
     configurable: true,


### PR DESCRIPTION
在子应用中创建的 dom 元素，将其标记为 contenteditable 时，此时通过键盘输入插入的元素 `el` 是子应用的 Node 的实例，但是 el.ownerDocument 会得到基座应用的 document，因为这些通过键盘输入插入的元素，并未被 `updateElementInfo` 方法处理，此时会出现一些异常，比如

```ts
el instanceof el.ownerDocument.defaultView.Node
```

上述表达式的值会是 `false`，但是正常情况下其值会是 `true`

因为 `el.ownerDocument.defaultView` 的值是基座应用的 `window` 对象，但是 `el` 是子应用的 `Node` 的类的实例