### PR TITLE
fix: initial dom in html escape out of the iframe sandbox environment

### DIFF
--- a/src/__tests__/demos/umd4/index.html
+++ b/src/__tests__/demos/umd4/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>umd4</title>
+</head>
+<body>
+  <div id='umd-root4'></div>
+  <script src="./index.js"></script>
+</body>
+</html>

--- a/src/__tests__/demos/umd4/index.js
+++ b/src/__tests__/demos/umd4/index.js
@@ -1,0 +1,14 @@
+function mount () {
+  const root = document.querySelector('#umd-root4')
+  const doc = root.ownerDocument;
+  const container = doc.createElement('div');
+  container.className = 'container';
+  root.appendChild(container);
+}
+
+function unmount () {
+  const root = document.querySelector('#umd-root4')
+  root && (root.innerHTML = '')
+}
+
+window['umd-app4'] = { mount, unmount }

--- a/src/__tests__/sandbox/effect.test.ts
+++ b/src/__tests__/sandbox/effect.test.ts
@@ -127,4 +127,28 @@ describe('sandbox effect', () => {
       }, false)
     })
   })
+
+  // 分支覆盖 -- iframe 沙箱下 html 内容中已存在元素的 instanceof 判定
+  test('coverage of instanceof judgement of element in html content under iframe sandbox', async () => {
+    const microAppElement5 = document.createElement('micro-app')
+    microAppElement5.setAttribute('name', 'test-app5')
+    microAppElement5.setAttribute('iframe', 'true');
+    microAppElement5.setAttribute('url', `http://127.0.0.1:${ports.effect}/umd4/`)
+
+    appCon.appendChild(microAppElement5)
+
+    await new Promise((resolve) => {
+      microAppElement5.addEventListener('mounted', () => {
+        setAppName('test-app5')
+        const app = appInstanceMap.get('test-app5')!
+
+        const proxyWindow = app.sandBox.proxyWindow;
+
+        expect(app.querySelector('#umd-root4') instanceof proxyWindow.Element).toBe(true)
+        expect(app.querySelector('.container') instanceof proxyWindow.Element).toBe(true)
+
+        resolve(true)
+      }, false)
+    })
+  })
 })

--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -425,37 +425,6 @@ export function pureCreateElement<K extends keyof MicroAppElementTagNameMap> (ta
   return element
 }
 
-/**
- * clone origin elements to target
- * @param origin Cloned element
- * @param target Accept cloned elements
- * @param deep deep clone or transfer dom
- */
-export function cloneContainer <T extends Element | ShadowRoot, Q extends Element | ShadowRoot> (
-  target: Q,
-  origin: T,
-  deep: boolean,
-): Q {
-  // 在基座接受到afterhidden方法后立即执行unmount，彻底destroy应用时，因为unmount时同步执行，所以this.container为null后才执行cloneContainer
-  if (origin) {
-    target.innerHTML = ''
-    if (deep) {
-      // TODO: ShadowRoot兼容，ShadowRoot不能直接使用cloneNode
-      const clonedNode = origin.cloneNode(true)
-      const fragment = document.createDocumentFragment()
-      Array.from(clonedNode.childNodes).forEach((node: Node | Element) => {
-        fragment.appendChild(node)
-      })
-      target.appendChild(fragment)
-    } else {
-      Array.from(origin.childNodes).forEach((node: Node | Element) => {
-        target.appendChild(node)
-      })
-    }
-  }
-  return target
-}
-
 // is invalid key of querySelector
 export function isInvalidQuerySelectorKey (key: string): boolean {
   if (__TEST__) return !key || /(^\d)|([^\w\d-_$])/gi.test(key)

--- a/src/source/index.ts
+++ b/src/source/index.ts
@@ -2,7 +2,6 @@ import type { AppInterface, fiberTasks } from '@micro-app/types'
 import {
   logError,
   CompletionPath,
-  pureCreateElement,
   injectFiberTask,
   serialExecFiberTasks,
   isLinkElement,
@@ -22,18 +21,6 @@ import {
 } from './scripts'
 import scopedCSS from '../sandbox/scoped_css'
 import globalEnv from '../libs/global_env'
-
-/**
- * transform html string to dom
- * @param str string dom
- */
-function getWrapElement (str: string): HTMLElement {
-  const wrapDiv = pureCreateElement('div')
-
-  wrapDiv.innerHTML = str
-
-  return wrapDiv
-}
 
 /**
  * Recursively process each child element
@@ -93,7 +80,7 @@ function flatChildren (
  * @param app app
  */
 export function extractSourceDom (htmlStr: string, app: AppInterface): void {
-  const wrapElement = getWrapElement(htmlStr)
+  const wrapElement = app.getDOMParser().parseFromString(htmlStr, 'text/html').body
   const microAppHead = globalEnv.rawElementQuerySelector.call(wrapElement, 'micro-app-head')
   const microAppBody = globalEnv.rawElementQuerySelector.call(wrapElement, 'micro-app-body')
 

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -213,6 +213,8 @@ declare module '@micro-app/types' {
     // get keep-alive state
     getKeepAliveState(): string | null
 
+    getDOMParser(): DOMParser
+
     // is app unmounted
     isUnmounted (): boolean
 


### PR DESCRIPTION
问题原因：

从 html 文件中加载的初始 dom 的所有实例是基座应用的 Element 的实例而不是 iframe 沙箱中 window.Element 的实例

https://github.com/micro-zoe/micro-app/blob/919a05a61ef189953e2665c278bfd1e309b7b930/src/source/index.ts#L30-L36

这里的 `getWrapElement` 方法创建的是基座的 `div` 元素，所以后续所有创建的元素都是基座的 dom 元素实例。

https://github.com/facebook/react/blob/c5b9375767e2c4102d7e5559d383523736f1c902/packages/react-dom-bindings/src/client/ReactFiberConfigDOM.js#L202-L208

在 React 源码中，底层会调用 `getOwnerDocumentFromRootContainer` 方法来根据 `createRoot` 方法中传入的 dom 元素来获取 `document` 实例。而由于这个 dom 是基座的 dom 实例，所以拿到的是基座的 `document`，因此创建的所有 dom 元素都是基座的实例，导致有所的关于 dom 元素的 instanceof 判定全部失效了。