### PR TITLE
fix: 父应用二级目录项目无法正常加载子应用

### DIFF
--- a/src/sandbox/iframe/index.ts
+++ b/src/sandbox/iframe/index.ts
@@ -78,7 +78,7 @@ export default class IframeSandbox {
 
   constructor (appName: string, url: string) {
     const rawLocation = globalEnv.rawWindow.location
-    const browserHost = rawLocation.protocol + '//' + rawLocation.host
+    const browserHost = rawLocation.protocol + '//' + rawLocation.host + rawLocation.pathname
 
     this.deleteIframeElement = this.createIframeElement(appName, browserHost)
     this.microAppWindow = this.iframe!.contentWindow


### PR DESCRIPTION
由于部分项目的父应用并未放在根路径下，所以会有可能存在无法访问的问题
例如：
父应用为：https://www.github.com/index.html 这样没有问题
但是如果父应用为： https://www.github.com/next/index.html 没有在根域名下的，包含二级目录的项目会存在问题