### PR TITLE
feat: 设置isFullPath=true支持二级路径

### DIFF
--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -50,6 +50,7 @@ export interface CreateAppParam {
   useSandbox: boolean
   inline?: boolean
   iframe?: boolean
+  isFullPath?: boolean
   container?: HTMLElement | ShadowRoot
   ssrUrl?: string
   isPrefetch?: boolean
@@ -76,6 +77,7 @@ export default class CreateApp implements AppInterface {
   public useSandbox: boolean
   public inline: boolean
   public iframe: boolean
+  public isFullPath: boolean
   public ssrUrl: string
   public isPrefetch: boolean
   public isPrerender: boolean
@@ -91,6 +93,7 @@ export default class CreateApp implements AppInterface {
     useSandbox,
     inline,
     iframe,
+    isFullPath,
     ssrUrl,
     isPrefetch,
     prefetchLevel,
@@ -104,6 +107,7 @@ export default class CreateApp implements AppInterface {
     this.scopecss = this.useSandbox && scopecss
     // exec before getInlineModeState
     this.iframe = iframe ?? false
+    this.isFullPath = isFullPath ?? false
     this.inline = this.getInlineModeState(inline)
     /**
      * NOTE:
@@ -705,7 +709,7 @@ export default class CreateApp implements AppInterface {
   private createSandbox (): void {
     if (this.useSandbox && !this.sandBox) {
       if (this.iframe) {
-        this.sandBox = new IframeSandbox(this.name, this.url)
+        this.sandBox = new IframeSandbox(this.name, this.url, this.isFullPath)
       } else {
         this.sandBox = new WithSandBox(this.name, this.url)
       }

--- a/src/sandbox/iframe/index.ts
+++ b/src/sandbox/iframe/index.ts
@@ -76,10 +76,11 @@ export default class IframeSandbox {
   public microHead!: HTMLHeadElement
   public microBody!: HTMLBodyElement
 
-  constructor (appName: string, url: string) {
+  constructor (appName: string, url: string, isFullPath: boolean) {
     const rawLocation = globalEnv.rawWindow.location
-    const browserHost = rawLocation.protocol + '//' + rawLocation.host
-
+    const defBrowserHost = rawLocation.protocol + '//' + rawLocation.host
+    // fullPath 主应用为二级路径需要pathname
+    const browserHost = !isFullPath ? defBrowserHost : defBrowserHost + rawLocation.pathname
     this.deleteIframeElement = this.createIframeElement(appName, browserHost)
     this.microAppWindow = this.iframe!.contentWindow
 
@@ -89,7 +90,7 @@ export default class IframeSandbox {
       // get escapeProperties from plugins
       this.getSpecialProperties(appName)
       // patch location & history of child app
-      this.proxyLocation = patchRouter(appName, url, this.microAppWindow, browserHost)
+      this.proxyLocation = patchRouter(appName, url, this.microAppWindow, defBrowserHost)
       // patch window of child app
       this.windowEffect = patchWindow(appName, this.microAppWindow, this)
       // patch document of child app


### PR DESCRIPTION
业务项目中存在主应用并不能直接挂载在一级目录中，iframe沙箱中提供isFullPath=true来兼容如下情况：
其目录结构如下：
```javascript
main-app/
child-app1/
child-app2/
....
```
其访问地址：
```javascript
// 主应用部署路径
www.example.com/main-app/index.html
// 子应用1
www.example.com/child-app1/index.html
// 子应用2
www.example.com/child-app2/index.html
```

