### PR TITLE
feat: micro-app custom elements support loose url parameter

### DIFF
--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -30,6 +30,7 @@ import {
   pureCreateElement,
   isDivElement,
   removeDomScope,
+  formatAppURL,
 } from './libs/utils'
 import dispatchLifecyclesEvent, {
   dispatchCustomEventToMicroApp,
@@ -98,7 +99,7 @@ export default class CreateApp implements AppInterface {
     appInstanceMap.set(name, this)
     // init actions
     this.name = name
-    this.url = url
+    this.url = formatAppURL(url)
     this.useSandbox = useSandbox
     this.scopecss = this.useSandbox && scopecss
     // exec before getInlineModeState
@@ -112,7 +113,7 @@ export default class CreateApp implements AppInterface {
 
     // not exist when prefetch 👇
     this.container = container ?? null
-    this.ssrUrl = ssrUrl ?? ''
+    this.ssrUrl = ssrUrl ? formatAppURL(ssrUrl) : ''
 
     // exist only prefetch 👇
     this.isPrefetch = isPrefetch ?? false


### PR DESCRIPTION
`micro-app` 支持宽松的 url 参数，例如下面的配置也可以正常 work：

> 假设基座应用的站点地址为 `https://www.example.com`

```html
<micro-app name="child-app" url="/child-app" />
<!-- 请求的地址为 https://www.example.com/child-app -->

<micro-app name="child-app" url="//cloud.example.com/child-app" />
<!-- 请求的地址为 https://cloud.example.com/child-app -->
```