### PR TITLE
css中url过滤编码后的#符号

### DIFF
--- a/src/sandbox/scoped_css.ts
+++ b/src/sandbox/scoped_css.ts
@@ -135,7 +135,7 @@ class CSSParser {
         (!this.scopecssDisable || this.scopecssDisableSelectors.length)
       ) {
         cssValue = cssValue.replace(/url\(["']?([^)"']+)["']?\)/gm, (all, $1) => {
-          if (/^((data|blob):|#)/.test($1) || /^(https?:)?\/\//.test($1)) {
+          if (/^((data|blob):|#|%23)/.test($1) || /^(https?:)?\/\//.test($1)) {
             return all
           }
 


### PR DESCRIPTION
unocss中svg格式的icon会将url中的字符进行编码，#会被编码成%23，导致子应用中的icon url会被添加baseurl，从而使icon无法正常显示，故需要过滤%23开头的url，不进行处理，直接返回原字符串