### PR TITLE
fix: The operation before hijacking the ownerdocument of the node

### DIFF
--- a/src/sandbox/iframe/element.ts
+++ b/src/sandbox/iframe/element.ts
@@ -13,6 +13,7 @@ import {
   isNode,
   isMicroAppBody,
   throttleDeferForSetAppName,
+  isFunction,
 } from '../../libs/utils'
 import {
   updateElementInfo,
@@ -164,6 +165,12 @@ function patchIframeNode (
     configurable: true,
     enumerable: true,
     get () {
+      if (isFunction(microApp.options.beforeHijackOwnerDocument)) {
+        const nodeRawOwnerDocument = rawOwnerDocumentDesc.get!.call(this)
+        if (microApp.options.beforeHijackOwnerDocument?.({ node: this, ownerDocument: nodeRawOwnerDocument, appName })) {
+          return nodeRawOwnerDocument
+        }
+      }
       return this.__PURE_ELEMENT__ || this === microDocument
         ? rawOwnerDocumentDesc.get!.call(this)
         : microDocument

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -359,6 +359,30 @@ declare module '@micro-app/types' {
     fetch?: fetchType
     globalAssets?: globalAssetsType,
     excludeAssetFilter?: (assetUrl: string) => boolean
+    /**
+     * The operation before hijacking the ownerdocument of the node
+     * true returns the ownerdocument of the node, false performs the next step
+     *
+     * Scenes:
+     *  1. tinymce editor
+     *
+     * Issue: https://github.com/micro-zoe/micro-app/issues/916
+     *
+     * @example
+     * ```js
+     * microApp.start({
+     *   beforeHijackOwnerDocument({ node, ownerDocument, appName }) {
+     *     return ownerDocument?.body?.id === 'tinymce'
+     *   }
+     * })
+     * ```
+     *
+     * @param params
+     * @param params.node - current node
+     * @param params.ownerDocument - node raw ownerDocument
+     * @param params.appName - current appName
+     */
+    beforeHijackOwnerDocument?: (params: { node: Node, ownerDocument: Document, appName: AppName }) => boolean
     getRootElementParentNode?: (node: Node, appName: AppName) => void
     customProxyDocumentProps?: Map<string | number | symbol, (value: unknown) => void>
   }


### PR DESCRIPTION
Closes #916 

tinymce 编辑器是采用 iframe 的方式来作为编辑区域，源代码有大量的 ownerDocument  的判断，必须是 tinymce 的 iframe 的 document 才能保证一些代码的逻辑无误，
以下截图是回车滚动条移动的关键代码，ownerDocument 被劫持成 micro-app iframe 的 document ，所以导致位置计算错误。
<img width="327" alt="image" src="https://github.com/micro-zoe/micro-app/assets/10841880/0e2e7d59-f832-419d-9c3f-0062c3073666">

以上仅仅作为一个例子。为了灵活扩展，这里新增了劫持方法前置拦截，更细粒度的处理元素的正确 ownerDocument
