### PR TITLE
fix: Corrected regular expression for close brace judgment

### DIFF
--- a/src/sandbox/scoped_css.ts
+++ b/src/sandbox/scoped_css.ts
@@ -159,7 +159,7 @@ class CSSParser {
     if (this.cssText.charAt(0) === '}') {
       if (!nesting) return
       if (nesting > 1) {
-        this.commonMatch(/}+/)
+        this.commonMatch(/}+\s*/)
       }
       return this.matchAllDeclarations(nesting - 1)
     }


### PR DESCRIPTION
The original regular expression will output multiple connected close brace, but the internal nested parameter will only be decremented by 1, causing the program to error.