### PR TITLE
fix(1.0.0-rc.6): fix error of iframe proxyWindow.document in FireFox

### DIFF
--- a/src/sandbox/adapter.ts
+++ b/src/sandbox/adapter.ts
@@ -205,7 +205,7 @@ export function updateElementInfo <T> (node: T, appName: string | null): T {
           ownerDocument: {
             configurable: true,
             enumerable: true,
-            get: () => node !== proxyWindow.document ? proxyWindow.document : null,
+            get: () => node !== proxyWindow.document || navigator?.userAgent?.indexOf('Firefox') > -1 ? proxyWindow.document : null,
           },
           parentNode: getIframeParentNodeDesc(
             appName,


### PR DESCRIPTION
Fix the issue of incorrect insertion of DOM nodes in popover in Firefox browse