### PR TITLE
fix: incorrect isSameOrigin check when loading blob with string url

### DIFF
--- a/src/proxies/worker.ts
+++ b/src/proxies/worker.ts
@@ -20,7 +20,7 @@ interface Worker {
 const originalWorker = window.Worker
 
 function isSameOrigin(url: string | URL): boolean {
-  if (url instanceof URL && url.protocol === 'blob:') {
+  if ((url instanceof URL && url.protocol === 'blob:') || (typeof url === 'string' && url.startsWith('blob:'))) {
     // 如果 url 是 Blob URL，直接返回 true
     return true
   }


### PR DESCRIPTION
Closes #1444 

微前端内部加载 worker 时，如果 url 为 string，则可能加载失败。isSameOrigin 判定逻辑未处理 typeof url === 'string' 的情况。