### PR TITLE
fix: 修复scopedCSS中new RegExp(prefix)中实例正则特殊字符报错问题

### DIFF
--- a/src/sandbox/scoped_css.ts
+++ b/src/sandbox/scoped_css.ts
@@ -510,21 +510,19 @@ export default function scopedCSS (
 
     if (!parser) parser = new CSSParser()
 
+    const escapeRegExp = (regStr: string) => regStr.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+
     if (styleElement.textContent) {
-      commonAction(
-        styleElement,
-        app.name,
-        prefix,
-        app.url,
-        linkPath,
-      )
+      commonAction(styleElement, app.name, prefix, app.url, linkPath)
+
       const observer = new MutationObserver(() => {
-        const isPrefixed = styleElement.textContent && new RegExp(prefix).test(styleElement.textContent)
+        const escapedPrefix = escapeRegExp(prefix)
+        const isPrefixed = styleElement.textContent && new RegExp(escapedPrefix).test(styleElement.textContent)
         observer.disconnect()
         if (!isPrefixed) {
           styleElement.__MICRO_APP_HAS_SCOPED__ = false
+          scopedCSS(styleElement, app, linkPath)
         }
-        scopedCSS(styleElement, app, linkPath)
       })
       observer.observe(styleElement, { childList: true, characterData: true })
     } else {


### PR DESCRIPTION
问题描述：
scopedCss中实例化正则字符串中含特殊字符报错
![WechatIMG3749](https://github.com/user-attachments/assets/12649017-1d9e-41c3-86ff-208f6d4af62b)

解决方案
![image](https://github.com/user-attachments/assets/5303ff6f-9e75-407d-9865-5a4fd72a4b61)
将正则字符串转义
同时还将scopedCss中的循环调用添加到if条件中