### PR TITLE
fix: adapter.ts/updateElementInfo当a标签configurable为false导致的bug

### DIFF
--- a/src/sandbox/adapter.ts
+++ b/src/sandbox/adapter.ts
@@ -157,7 +157,9 @@ export function updateElementInfo <T> (node: T, appName: string | null): T {
     if (isAnchorElement(node)) {
       // a 标签
       const microApp = AppManager.getInstance().get(appName)
-      if (microApp) {
+      const hrefDescriptor = Object.getOwnPropertyDescriptor(node, 'href')
+      const hrefConfigurable = hrefDescriptor?.configurable || !hrefDescriptor
+      if (microApp && hrefConfigurable) {
         props.href = {
           get() {
             return this.getAttribute('href')


### PR DESCRIPTION
【bug修复】
修复了一个bug,该bug导致嵌套3层vue页面的场景下（应用a>应用b>应用c），当被嵌套的第3层页面包含a标签时无法正常加载。
【bug原因】
vue2会将a标签href属性的属性描述符configurable设为false。相关代码（adapter.ts/updateElementInfo）在调用rawDefineProperties前未作判别
----------------------------------------------------
## 问题描述
> 在3层嵌套vue页面场景下（应用a>应用b>应用c），当应用c页面包含a标签时，无法加载应用c，应用c页面空白。

## 复现步骤
1.应用a加载应用b,应用b加载应用c,3个应用均为vue2项目
2.应用c被加载页面包含a标签（无a标签时表现正常）

## 上传截图
> 
<img width="619" alt="image" src="https://github.com/user-attachments/assets/5817e6d8-9ed0-4ee1-a736-a098b093a5d0" />


## 复现仓库
> https://github.com/252352801/microApp_href_defineProperties_bug

## 环境信息
- micro-app版本：1.0.0-rc.20
- 主应用前端框架&版本：vue@^2.6.14
- 子应用前端框架&版本：vue@^2.6.14
- 构建工具&版本：node@16.20.2，yarn@1.22.19
