### PR TITLE
fix: MutationObserver在火狐浏览不生效问题

### DIFF
--- a/src/sandbox/scoped_css.ts
+++ b/src/sandbox/scoped_css.ts
@@ -524,7 +524,7 @@ export default function scopedCSS (
           scopedCSS(styleElement, app, linkPath)
         }
       })
-      observer.observe(styleElement, { childList: true, characterData: true })
+      observer.observe(styleElement, { childList: true, characterData: true, subtree: true })
     } else {
       const observer = new MutationObserver(function () {
         observer.disconnect()


### PR DESCRIPTION
MutationObserver 增加subtree为true的配置，不然在火狐浏览器不生效，不执行回调，导致子应用cssInjs框架如Antd样式隔离失效问题