### PR TITLE
fix: should dispatch error event when mount error

### DIFF
--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -336,6 +336,7 @@ export default class CreateApp implements AppInterface {
                   }
                 } catch (e) {
                   logError('An error occurred when mount \n', this.name, e)
+                  this.onerror(e)
                 }
               }
             }
@@ -353,6 +354,7 @@ export default class CreateApp implements AppInterface {
             this.handleMounted(this.umdHookMount!(microApp.getData(this.name, true)))
           } catch (e) {
             logError('An error occurred when mount \n', this.name, e)
+            this.onerror(e)
           }
         }
       }
@@ -383,6 +385,8 @@ export default class CreateApp implements AppInterface {
           .then(nextAction)
           .catch((e) => {
             logError('An error occurred in window.mount \n', this.name, e)
+            this.onerror(e)
+            // TODO: 为什么 error 还要继续 nextAction?
             nextAction()
           })
       } else {


### PR DESCRIPTION
现状：error 这个生命周期事件，只有在 fetch html 入口有问题才会 dispatch，不符合预期

应用场景：
1. 如子应用的 `window.mount` 发生异常，整个 `<micro-app>` 无法渲染卡住，但是主应用收不到通知
2. 另外还有一种场景**待解决**，iframe 沙箱模式加载子应用，fetch html 成功，但是子应用某些静态资源加载失败（可能是逻辑原因或网络原因），这时整个加载过程也会卡住，主应用收不到通知