### PR TITLE
fix: 支持 file:// 协议子应用路径

### DIFF
--- a/src/libs/utils.ts
+++ b/src/libs/utils.ts
@@ -319,6 +319,9 @@ export function formatAppURL(url: string | null, appName: string | null = null):
      * BUG FIX: Never using '/' to complete url, refer to https://github.com/jd-opensource/micro-app/issues/1147
      */
     const fullPath = `${origin}${pathname}${search}`
+    if (/^file:\/\//.test(fullPath)) {
+      return fullPath
+    }
     return /^https?:\/\//.test(fullPath) ? fullPath : ''
   } catch (e) {
     logError(e, appName)


### PR DESCRIPTION
当前情况：`micro-app` 传入 url 为 `file://` 协议路径时，会报错 `[micro-app] app xxx: Invalid attribute url`

使用场景：移动端、electron 桌面端等情景，加载已下载到本地的子应用 webapp 资源包