### PR TITLE
fix: 修复 mini-css-extract-plugin 的 hmr 不生效的问题

### DIFF
--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -39,6 +39,7 @@ import sourceCenter from './source/source_center'
 
 // micro app instances
 export const appInstanceMap = new Map<string, AppInterface>()
+export const appCurrentScriptMap = new Map<string, HTMLScriptElement>()
 
 // params of CreateApp
 export interface CreateAppParam {

--- a/src/sandbox/with/document.ts
+++ b/src/sandbox/with/document.ts
@@ -14,6 +14,7 @@ import {
   rawDefineProperties,
 } from '../../libs/utils'
 import {
+  appCurrentScriptMap,
   appInstanceMap,
 } from '../../create_app'
 import {
@@ -232,6 +233,8 @@ function createProxyDocument (
       if (key === 'removeEventListener') return removeEventListener
       if (key === 'microAppElement') return appInstanceMap.get(appName)?.container
       if (key === '__MICRO_APP_NAME__') return appName
+      // mini-css-extract-plugin in hmr mode depends on document.currentScript to map module-id to chunk file href
+      if (key === 'currentScript') return appCurrentScriptMap.get(appName)
       return bindFunctionToRawTarget<Document>(Reflect.get(target, key), rawDocument, 'DOCUMENT')
     },
     set: (target: Document, key: PropertyKey, value: unknown): boolean => {


### PR DESCRIPTION
`rsbuild` 默认使用 `mini-css-extract-plugin` 处理 css，它的热更新能力是通过替换 `<link/>` 标签实现的。

目前 `micro-app` 为了实现 CSS 隔离，将 `<link/>` 替换成了 `<style/>`。这导致 `mini-css-extract-plugin` 的热更新能力无法生效。

可以通过插入 `<link disabled="true" />` 的标签，既可以避免原样式的加载，也可以让 `mini-css-extract-plugin` 的热更新能力生效

同时为 `with` 沙箱加一下 `document.currentScript`\
`mini-css-extract-plugin` 会通过该字段记录 `module-id` -> `chunk href` 的映射关系。\
`hmr` 的具体实现可以参考 `hotModuleReplacement.js` \
https://github.com/webpack-contrib/mini-css-extract-plugin/blob/master/src/hmr/hotModuleReplacement.js

修复：#1510