### PR TITLE
fix: javascript 资源加载完成时，如果 microapp 已经卸载，则不应该执行该文件

### DIFF
--- a/src/create_app.ts
+++ b/src/create_app.ts
@@ -78,6 +78,7 @@ export default class CreateApp implements AppInterface {
   public isPrefetch: boolean
   public isPrerender: boolean
   public prefetchLevel?: number
+  public mountIdentifier?: symbol
   public fiber = false
   public routerMode: string
   public attrs?: Record<string, string>
@@ -287,6 +288,7 @@ export default class CreateApp implements AppInterface {
         this.routerMode = routerMode
 
         const dispatchBeforeMount = () => {
+          this.mountIdentifier = Symbol('mountIdentifier')
           dispatchLifecyclesEvent(
             this.container,
             this.name,
@@ -493,6 +495,8 @@ export default class CreateApp implements AppInterface {
     unmountcb?: CallableFunction,
     umdHookUnmountResult?: unknown,
   ): void {
+    this.mountIdentifier = undefined
+
     // dispatch state event to micro app
     dispatchCustomEventToMicroApp(this, 'statechange', {
       appState: appStates.UNMOUNT

--- a/typings/global.d.ts
+++ b/typings/global.d.ts
@@ -190,6 +190,7 @@ declare module '@micro-app/types' {
     isPrerender: boolean
     isReloading?: boolean
     prefetchLevel?: number
+    mountIdentifier?: symbol // used to identify if the app has been unmounted between async calls
     // defaultPage: string // default page when mount
     // baseroute: string // route prefix, default is ''
     // hiddenRouter: boolean // hide router info of child from browser url


### PR DESCRIPTION
microapp 卸载时，会停止 `with` 沙箱。这时如果执行 js 文件，会泄漏到主应用

修复: #1606 