### PR TITLE
fix: with 沙箱没有 Worker Proxy，且 Worker Proxy 没有处理 classic 模式

### DIFF
--- a/src/proxies/worker.ts
+++ b/src/proxies/worker.ts
@@ -78,10 +78,16 @@ const WorkerProxy = new Proxy<Worker>(originalWorker, {
     }
 
     if (url && !isSameOrigin(url)) {
+      let workerPath = scriptURL
       // 如果 scriptURL 是跨域的，使用 Blob URL 加载并执行 worker
-      const script = `import "${scriptURL}";`
-      const workerPath = urlFromScript(script)
-      options.type = 'module'
+      // 应该遵总 worker 的 type 类型。classic worker
+      if (options.type === 'module') {
+        const script = `import "${scriptURL}";`
+        workerPath = urlFromScript(script)
+      } else {
+        const script = `importScripts("${scriptURL}");`
+        workerPath = urlFromScript(script)
+      }
       return new Target(workerPath, options) as WorkerInstance
     } else {
       // 如果 scriptURL 是同源的，直接使用原生的 Worker 构造函数

--- a/src/sandbox/with/window.ts
+++ b/src/sandbox/with/window.ts
@@ -26,6 +26,7 @@ import {
 import {
   appInstanceMap,
 } from '../../create_app'
+import WorkerProxy from '../../proxies/worker'
 
 /**
  * patch window of child app
@@ -87,9 +88,18 @@ function createProxyWindow (
   const rawWindow = globalEnv.rawWindow
   const descriptorTargetMap = new Map<PropertyKey, 'target' | 'rawWindow'>()
 
+  Object.defineProperty(microAppWindow, 'Worker', {
+    value: WorkerProxy,
+    configurable: true,
+    writable: true,
+  })
+
   const proxyWindow = new Proxy(microAppWindow, {
     get: (target: microAppWindowType, key: PropertyKey): unknown => {
       throttleDeferForSetAppName(appName)
+      if (key === 'Worker') {
+        return WorkerProxy
+      }
       if (
         Reflect.has(target, key) ||
         (isString(key) && /^__MICRO_APP_/.test(key)) ||


### PR DESCRIPTION
问题一：with 沙箱中没有 Worker 的代理。导致 worker 因同源问题，无法加载。
问题二：Worker 代理写死为 module 模式。加载 classic worker 时，importScripts 会报错，导致无法加载