### PR TITLE
fix: handle remaining Tailwind v4 scoped CSS cases

### DIFF
--- a/src/__tests__/source/scoped_css.test.ts
+++ b/src/__tests__/source/scoped_css.test.ts
@@ -13,7 +13,6 @@ const md5 = (content: string) => {
   return createHash('md5').update(content).digest('hex')
 }
 
-
 describe('source scoped_css', () => {
   let appCon: Element
   beforeAll(() => {
@@ -101,12 +100,12 @@ describe('source scoped_css', () => {
         setAppName('test-app3')
         // 动态创建style
         const dynamicStyle = document.createElement('style')
-        dynamicStyle.textContent = '@font-face {font-family: test-font;} @media screen and (max-width: 300px) {body {background:lightblue;}} @supports (display: grid) {div {display: grid;}} @unknown {}'
+        dynamicStyle.textContent = '@font-face {font-family: test-font;} @property --tw-translate-x { syntax: "*"; inherits: false; initial-value: 0; } @media screen and (max-width: 300px) {body {background:lightblue;}} @supports (display: grid) {div {display: grid;}} @unknown {}'
 
         document.head.appendChild(dynamicStyle)
 
         defer(() => {
-          expect(dynamicStyle.textContent).toBe('@font-face {font-family: test-font;} @media screen and (max-width: 300px) {micro-app[name=test-app3] micro-app-body{background:lightblue;}} @supports (display: grid) {micro-app[name=test-app3] div{display: grid;}} micro-app[name=test-app3] @unknown{}')
+          expect(dynamicStyle.textContent).toBe('@font-face {font-family: test-font;} @property --tw-translate-x { syntax: "*"; inherits: false; initial-value: 0; } @media screen and (max-width: 300px) {micro-app[name=test-app3] micro-app-body{background:lightblue;}} @supports (display: grid) {micro-app[name=test-app3] div{display: grid;}} micro-app[name=test-app3] @unknown{}')
           resolve(true)
         })
       }, false)
@@ -404,6 +403,12 @@ describe('source scoped_css', () => {
         dynamicStyle7.textContent = '.test1,   .test2 {color: red}'
         document.head.appendChild(dynamicStyle7)
         expect(dynamicStyle7.textContent).toBe('micro-app[name=test-app11] .test1,   micro-app[name=test-app11] .test2{color: red}')
+
+        // keep commas inside pseudo-class arguments and escaped arbitrary values
+        const dynamicStyle8 = document.createElement('style')
+        dynamicStyle8.textContent = ':is(.a, .b):has(+ .c, + .d){} .grid-cols-\\[minmax\\(0\\,_1fr\\)\\]{grid-template-columns:minmax(0, 1fr)}'
+        document.head.appendChild(dynamicStyle8)
+        expect(dynamicStyle8.textContent).toBe('micro-app[name=test-app11] :is(.a, .b):has(+ .c, + .d){} micro-app[name=test-app11] .grid-cols-\\[minmax\\(0\\,_1fr\\)\\]{grid-template-columns:minmax(0, 1fr)}')
 
         resolve(true)
       }, false)

--- a/src/sandbox/scoped_css.ts
+++ b/src/sandbox/scoped_css.ts
@@ -115,7 +115,7 @@ class CSSParser {
       return match.replace(p2, mock)
     })
 
-    return matchRes.replace(/(^|,[\n\s]*)([^,]+)/g, (_, separator, selector) => {
+    const scopeSelector = (separator: string, selector: string): string => {
       selector = trim(selector)
       selector = selector.replace(/\[[^\]=]+(?:=([^\]]+))?\]/g, (match:string, p1: string) => {
         if (attributeValues[p1]) {
@@ -141,7 +141,42 @@ class CSSParser {
       }
 
       return separator + selector
-    })
+    }
+
+    const selectors: Array<string> = []
+    let selectorStart = 0
+    let selectorSeparator = ''
+    let bracketDepth = 0
+    let parenDepth = 0
+
+    for (let i = 0; i < matchRes.length; i++) {
+      const char = matchRes[i]
+      if (char === '\\') {
+        i++
+        continue
+      }
+
+      if (char === '[') {
+        bracketDepth++
+      } else if (char === ']') {
+        bracketDepth = Math.max(0, bracketDepth - 1)
+      } else if (char === '(') {
+        parenDepth++
+      } else if (char === ')') {
+        parenDepth = Math.max(0, parenDepth - 1)
+      } else if (char === ',' && bracketDepth === 0 && parenDepth === 0) {
+        selectors.push(scopeSelector(selectorSeparator, matchRes.slice(selectorStart, i)))
+
+        const separatorMatch = /^,[\n\s]*/.exec(matchRes.slice(i))
+        selectorSeparator = separatorMatch ? separatorMatch[0] : ','
+        i += selectorSeparator.length - 1
+        selectorStart = i + 1
+      }
+    }
+
+    selectors.push(scopeSelector(selectorSeparator, matchRes.slice(selectorStart)))
+
+    return selectors.join('')
   }
 
   // https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleDeclaration
@@ -220,6 +255,7 @@ class CSSParser {
       this.pageRule() ||
       this.hostRule() ||
       this.fontFaceRule() ||
+      this.propertyRule() ||
       this.layerRule()
   }
 
@@ -297,6 +333,13 @@ class CSSParser {
     if (!this.commonMatch(/^@font-face\s*/)) return false
 
     return this.commonHandlerForAtRuleWithSelfRule('font-face')
+  }
+
+  // https://developer.mozilla.org/en-US/docs/Web/CSS/@property
+  private propertyRule (): boolean | void {
+    if (!this.commonMatch(/^@property\s+([^{]+)/)) return false
+
+    return this.commonHandlerForAtRuleWithSelfRule('property')
   }
 
   // https://developer.mozilla.org/en-US/docs/Web/CSS/@layer


### PR DESCRIPTION
## Background

Tailwind CSS v4 support was tracked in #1550 and the follow-up PR #1628 was released in 1.0.0-rc.30. That PR fixed the `@layer` parsing path, but there are still two scoped CSS parser cases that make Tailwind v4 output invalid in child apps.

In a real micro-app integration using `@micro-zoe/micro-app@1.0.0-rc.30`, styles were still missing after upgrading because Tailwind v4 emits CSS that includes:

- CSS registered custom properties such as `@property --tw-* { ... }`.
- Selectors/classes containing commas that are not selector-list separators, especially arbitrary values and modern pseudo-class arguments.

This also matches the currently open #1690 report, where the failing Tailwind class contains an arbitrary gradient value: `group-hover:bg-[linear-gradient(180deg,transparent_60%,rgba(0,_0,_0,_.6)_93%)]`.

## Root cause

1. `CSSParser.matchAtRule()` does not recognize `@property`. When scoped CSS parses Tailwind v4 output, the parser falls through to the normal style-rule path and can incorrectly scope `@property` as if it were a selector. The resulting CSS is invalid, so browser-side style application diverges from direct child-app access.

2. `formatSelector()` currently splits selector lists with a regular expression that treats every comma as a selector separator. That works for simple selector lists like `.a, .b`, but it is not safe for Tailwind v4 / modern CSS output where commas can appear inside:

- `:is(...)` / `:where(...)` / `:has(...)` arguments.
- Escaped arbitrary utility names such as `.grid-cols-\[minmax\(0\,_1fr\)\]`.
- Arbitrary values/functions such as `linear-gradient(...)` and nested `rgba(...)`.

When those inner commas are split as top-level selector separators, scoped CSS inserts `micro-app[name=xxx]` into the middle of one logical selector, causing the corresponding Tailwind rule to stop matching.

## Changes

- Add a dedicated `@property` rule parser and handle it like other self-contained at-rules.
- Replace the selector-list regex splitter with a small stateful scanner.
  - Tracks bracket depth.
  - Tracks parenthesis depth.
  - Skips escaped characters.
  - Splits only on top-level commas.
- Keep the existing behavior for simple selector lists and body/root handling.
- Add regression coverage for:
  - `@property --tw-*`.
  - Commas inside `:is()` / `:has()`.
  - Escaped Tailwind arbitrary class selectors containing a comma.

## Why this is separate from #1628

#1628 fixed one Tailwind v4 blocker around `@layer` statement/block parsing and was included in 1.0.0-rc.30. The remaining failures described here are different parser gaps:

- `@property` is still not recognized as an at-rule.
- The selector splitter is still comma-regex based and cannot distinguish top-level selector separators from commas inside modern selector/function syntax.

So users on rc.30 can still see missing styles even though #1550 is closed, especially when Tailwind emits arbitrary utilities or registered custom properties.

## Validation

- `npm ci`
- `npx jest src/__tests__/source/scoped_css.test.ts --runInBand --setupFiles <temporary Worker mock>`
  - The temporary Worker mock is only for the local Node 22 + JSDOM environment; without it the existing `WorkerProxy` initialization fails before scoped CSS tests run because `window.Worker` is undefined.
  - Result: 9 passed, 3 skipped.
- `npx eslint src/sandbox/scoped_css.ts`
- `npx eslint --no-ignore src/__tests__/source/scoped_css.test.ts`
- `git diff --check`
- `npm run build`

Fixes #1690.
Related to #1550 and #1628.